### PR TITLE
Enable distributed CI and add Prisma generate target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Uncomment this line to enable task distribution
-      # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+      - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
       - uses: actions/setup-node@v4

--- a/apps/backend-services/package.json
+++ b/apps/backend-services/package.json
@@ -4,8 +4,22 @@
   "private": true,
   "nx": {
     "targets": {
+      "prisma:generate": {
+        "executor": "nx:run-commands",
+        "outputs": [
+          "{projectRoot}/node_modules/.prisma"
+        ],
+        "cache": true,
+        "options": {
+          "command": "prisma generate --schema={projectRoot}/prisma/schema.prisma"
+        }
+      },
       "build": {
         "executor": "@nx/esbuild:esbuild",
+        "dependsOn": [
+          "prisma:generate",
+          "^build"
+        ],
         "outputs": [
           "{options.outputPath}"
         ],


### PR DESCRIPTION
Uncommented the distributed CI run command in the workflow to enable task distribution. Added a 'prisma:generate' target to backend-services with caching and output configuration, and made 'build' depend on Prisma generation for proper schema handling.